### PR TITLE
Added option to enable sliding of wizard

### DIFF
--- a/src/ion-wizard.js
+++ b/src/ion-wizard.js
@@ -31,8 +31,8 @@ angular.module('ionic.wizard', [])
             }],
             link: function (scope, element, attrs, controller) {
                 var currentIndex = 0;
-
-                $ionicSlideBoxDelegate.enableSlide(false);
+                var enableSlide = attrs.enableslide === "true" ? true : false;
+                $ionicSlideBoxDelegate.enableSlide(enableSlide);
 
                 element.css('height', '100%');
 


### PR DESCRIPTION
Added the option "enableslide" so that one can choose to enable sliding of the wizard.
Just add the attribute enableslide="true" to the ion-slide-box element. Not adding the attribute leads to the default behaviour.
